### PR TITLE
Make the signing module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,5 +53,5 @@ mod bucket;
 pub mod credentials;
 mod map;
 mod method;
-mod signing;
+pub mod signing;
 pub(crate) mod sorting_iter;


### PR DESCRIPTION
This will allow users to use the `sign` function.