### PR TITLE
change Bucket::new() Implementation

### DIFF
--- a/benches/actions.rs
+++ b/benches/actions.rs
@@ -13,7 +13,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let region = "us-east-1";
 
         let credentials = Credentials::new(key.into(), secret.into());
-        let bucket = Bucket::new(url, true, name.into(), region.into()).unwrap();
+        let bucket = Bucket::new(url, true, name, region).unwrap();
 
         b.iter(|| {
             let object = "text.txt";

--- a/benches/actions.rs
+++ b/benches/actions.rs
@@ -12,7 +12,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let name = "examplebucket";
         let region = "us-east-1";
 
-        let credentials = Credentials::new(key.into(), secret.into());
+        let credentials = Credentials::new(key, secret);
         let bucket = Bucket::new(url, true, name, region).unwrap();
 
         b.iter(|| {

--- a/examples/create_bucket.rs
+++ b/examples/create_bucket.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<(), Box<dyn StdError>> {
     let region = "minio";
 
     let bucket = Bucket::new(url, true, "test1234", region).unwrap();
-    let credential = Credentials::new(key.into(), secret.into());
+    let credential = Credentials::new(key, secret);
 
     let action = CreateBucket::new(&bucket, &credential);
     let signed_url = action.sign(ONE_HOUR);

--- a/examples/create_bucket.rs
+++ b/examples/create_bucket.rs
@@ -11,12 +11,12 @@ const ONE_HOUR: Duration = Duration::from_secs(3600);
 async fn main() -> Result<(), Box<dyn StdError>> {
     let client = Client::new();
 
-    let url = "http://localhost:9000".parse().unwrap();
-    let key = "minioadmin";
-    let secret = "minioadmin";
+    let url = "http://172.22.98.45:9000".parse().unwrap();
+    let key = "ccc";
+    let secret = "WXZFwxzf123";
     let region = "minio";
 
-    let bucket = Bucket::new(url, true, "test123".into(), region.into()).unwrap();
+    let bucket = Bucket::new(url, true, "test1234".into(), region.into()).unwrap();
     let credential = Credentials::new(key.into(), secret.into());
 
     let action = CreateBucket::new(&bucket, &credential);

--- a/examples/create_bucket.rs
+++ b/examples/create_bucket.rs
@@ -11,12 +11,12 @@ const ONE_HOUR: Duration = Duration::from_secs(3600);
 async fn main() -> Result<(), Box<dyn StdError>> {
     let client = Client::new();
 
-    let url = "http://172.22.98.45:9000".parse().unwrap();
-    let key = "ccc";
-    let secret = "WXZFwxzf123";
+    let url = "http://localhost:9000".parse().unwrap();
+    let key = "minioadmin";
+    let secret = "minioadmin";
     let region = "minio";
 
-    let bucket = Bucket::new(url, true, "test1234".into(), region.into()).unwrap();
+    let bucket = Bucket::new(url, true, "test1234", region).unwrap();
     let credential = Credentials::new(key.into(), secret.into());
 
     let action = CreateBucket::new(&bucket, &credential);

--- a/examples/list_objects.rs
+++ b/examples/list_objects.rs
@@ -11,12 +11,12 @@ const ONE_HOUR: Duration = Duration::from_secs(3600);
 async fn main() -> Result<(), Box<dyn StdError>> {
     let client = Client::new();
 
-    let url = "http://localhost:9000".parse().unwrap();
-    let key = "minioadmin";
-    let secret = "minioadmin";
+    let url = "http://172.22.98.45:9000".parse().unwrap();
+    let key = "ccc";
+    let secret = "WXZFwxzf123";
     let region = "minio";
 
-    let bucket = Bucket::new(url, true, "test".into(), region.into()).unwrap();
+    let bucket = Bucket::new(url, true, "bucket0".into(), region.into()).unwrap();
     let credential = Credentials::new(key.into(), secret.into());
 
     let action = ListObjectsV2::new(&bucket, Some(&credential));

--- a/examples/list_objects.rs
+++ b/examples/list_objects.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<(), Box<dyn StdError>> {
     let region = "minio";
 
     let bucket = Bucket::new(url, true, "test", region).unwrap();
-    let credential = Credentials::new(key.into(), secret.into());
+    let credential = Credentials::new(key, secret);
 
     let action = ListObjectsV2::new(&bucket, Some(&credential));
     let signed_url = action.sign(ONE_HOUR);

--- a/examples/list_objects.rs
+++ b/examples/list_objects.rs
@@ -11,12 +11,12 @@ const ONE_HOUR: Duration = Duration::from_secs(3600);
 async fn main() -> Result<(), Box<dyn StdError>> {
     let client = Client::new();
 
-    let url = "http://172.22.98.45:9000".parse().unwrap();
-    let key = "ccc";
-    let secret = "WXZFwxzf123";
+    let url = "http://localhost:9000".parse().unwrap();
+    let key = "minioadmin";
+    let secret = "minioadmin";
     let region = "minio";
 
-    let bucket = Bucket::new(url, true, "bucket0".into(), region.into()).unwrap();
+    let bucket = Bucket::new(url, true, "test", region).unwrap();
     let credential = Credentials::new(key.into(), secret.into());
 
     let action = ListObjectsV2::new(&bucket, Some(&credential));

--- a/examples/multipart_upload.rs
+++ b/examples/multipart_upload.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn StdError>> {
     let region = "minio";
 
     let bucket = Bucket::new(url, true, "test", region).unwrap();
-    let credential = Credentials::new(key.into(), secret.into());
+    let credential = Credentials::new(key, secret);
 
     let action = CreateMultipartUpload::new(&bucket, Some(&credential), "idk.txt");
     let url = action.sign(ONE_HOUR);

--- a/examples/multipart_upload.rs
+++ b/examples/multipart_upload.rs
@@ -13,12 +13,12 @@ const ONE_HOUR: Duration = Duration::from_secs(3600);
 async fn main() -> Result<(), Box<dyn StdError>> {
     let client = Client::new();
 
-    let url = "http://172.22.98.45:9000".parse().unwrap();
-    let key = "ccc";
-    let secret = "WXZFwxzf123";
+    let url = "http://localhost:9000".parse().unwrap();
+    let key = "minioadmin";
+    let secret = "minioadmin";
     let region = "minio";
 
-    let bucket = Bucket::new(url, true, "test".into(), region.into()).unwrap();
+    let bucket = Bucket::new(url, true, "test", region).unwrap();
     let credential = Credentials::new(key.into(), secret.into());
 
     let action = CreateMultipartUpload::new(&bucket, Some(&credential), "idk.txt");

--- a/examples/multipart_upload.rs
+++ b/examples/multipart_upload.rs
@@ -13,9 +13,9 @@ const ONE_HOUR: Duration = Duration::from_secs(3600);
 async fn main() -> Result<(), Box<dyn StdError>> {
     let client = Client::new();
 
-    let url = "http://localhost:9000".parse().unwrap();
-    let key = "minioadmin";
-    let secret = "minioadmin";
+    let url = "http://172.22.98.45:9000".parse().unwrap();
+    let key = "ccc";
+    let secret = "WXZFwxzf123";
     let region = "minio";
 
     let bucket = Bucket::new(url, true, "test".into(), region.into()).unwrap();

--- a/examples/sign_get.rs
+++ b/examples/sign_get.rs
@@ -6,15 +6,15 @@ use rusty_s3::{Bucket, Credentials};
 const ONE_HOUR: Duration = Duration::from_secs(3600);
 
 fn main() {
-    let url = "http://localhost:9000".parse().unwrap();
-    let key = "minioadmin";
-    let secret = "minioadmin";
+    let url = "http://172.22.98.45:9000".parse().unwrap();
+    let key = "ccc";
+    let secret = "WXZFwxzf123";
     let region = "minio";
 
-    let bucket = Bucket::new(url, true, "test".into(), region.into()).unwrap();
+    let bucket = Bucket::new(url, true, "bucket0".into(), region.into()).unwrap();
     let credential = Credentials::new(key.into(), secret.into());
 
-    let mut action = GetObject::new(&bucket, Some(&credential), "img.jpg");
+    let mut action = GetObject::new(&bucket, Some(&credential), "test.md");
     action
         .query_mut()
         .insert("response-cache-control", "no-cache, no-store");

--- a/examples/sign_get.rs
+++ b/examples/sign_get.rs
@@ -12,7 +12,7 @@ fn main() {
     let region = "minio";
 
     let bucket = Bucket::new(url, true, "test", region).unwrap();
-    let credential = Credentials::new(key.into(), secret.into());
+    let credential = Credentials::new(key, secret);
 
     let mut action = GetObject::new(&bucket, Some(&credential), "img.jpg");
     action

--- a/examples/sign_get.rs
+++ b/examples/sign_get.rs
@@ -6,15 +6,15 @@ use rusty_s3::{Bucket, Credentials};
 const ONE_HOUR: Duration = Duration::from_secs(3600);
 
 fn main() {
-    let url = "http://172.22.98.45:9000".parse().unwrap();
-    let key = "ccc";
-    let secret = "WXZFwxzf123";
+    let url = "http://localhost:9000".parse().unwrap();
+    let key = "minioadmin";
+    let secret = "minioadmin";
     let region = "minio";
 
-    let bucket = Bucket::new(url, true, "bucket0".into(), region.into()).unwrap();
+    let bucket = Bucket::new(url, true, "test", region).unwrap();
     let credential = Credentials::new(key.into(), secret.into());
 
-    let mut action = GetObject::new(&bucket, Some(&credential), "test.md");
+    let mut action = GetObject::new(&bucket, Some(&credential), "img.jpg");
     action
         .query_mut()
         .insert("response-cache-control", "no-cache, no-store");

--- a/examples/sign_put.rs
+++ b/examples/sign_put.rs
@@ -6,12 +6,12 @@ use rusty_s3::{Bucket, Credentials};
 const ONE_HOUR: Duration = Duration::from_secs(3600);
 
 fn main() {
-    let url = "http://localhost:9000".parse().unwrap();
-    let key = "minioadmin";
-    let secret = "minioadmin";
+    let url = "http://172.22.98.45:9000".parse().unwrap();
+    let key = "ccc";
+    let secret = "ccc";
     let region = "minio";
 
-    let bucket = Bucket::new(url, true, "test".into(), region.into()).unwrap();
+    let bucket = Bucket::new(url, true, "test123".into(), region.into()).unwrap();
     let credential = Credentials::new(key.into(), secret.into());
 
     let action = PutObject::new(&bucket, Some(&credential), "duck.jpg");

--- a/examples/sign_put.rs
+++ b/examples/sign_put.rs
@@ -12,7 +12,7 @@ fn main() {
     let region = "minio";
 
     let bucket = Bucket::new(url, true, "test123", region).unwrap();
-    let credential = Credentials::new(key.into(), secret.into());
+    let credential = Credentials::new(key, secret);
 
     let action = PutObject::new(&bucket, Some(&credential), "duck.jpg");
     let signed_url = action.sign(ONE_HOUR);

--- a/examples/sign_put.rs
+++ b/examples/sign_put.rs
@@ -6,12 +6,12 @@ use rusty_s3::{Bucket, Credentials};
 const ONE_HOUR: Duration = Duration::from_secs(3600);
 
 fn main() {
-    let url = "http://172.22.98.45:9000".parse().unwrap();
-    let key = "ccc";
-    let secret = "ccc";
+    let url = "http://localhost:9000".parse().unwrap();
+    let key = "minioadmin";
+    let secret = "minioadmin";
     let region = "minio";
 
-    let bucket = Bucket::new(url, true, "test123".into(), region.into()).unwrap();
+    let bucket = Bucket::new(url, true, "test123", region).unwrap();
     let credential = Credentials::new(key.into(), secret.into());
 
     let action = PutObject::new(&bucket, Some(&credential), "duck.jpg");

--- a/src/actions/create_bucket.rs
+++ b/src/actions/create_bucket.rs
@@ -88,8 +88,7 @@ mod tests {
         let expires_in = Duration::from_secs(86400);
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
-        let bucket =
-            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
+        let bucket = Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
             "AKIAIOSFODNN7EXAMPLE",
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",

--- a/src/actions/create_bucket.rs
+++ b/src/actions/create_bucket.rs
@@ -89,7 +89,7 @@ mod tests {
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
         let bucket =
-            Bucket::new(endpoint, false, "examplebucket".into(), "us-east-1".into()).unwrap();
+            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
             "AKIAIOSFODNN7EXAMPLE".into(),
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),

--- a/src/actions/create_bucket.rs
+++ b/src/actions/create_bucket.rs
@@ -91,8 +91,8 @@ mod tests {
         let bucket =
             Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
-            "AKIAIOSFODNN7EXAMPLE".into(),
-            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
+            "AKIAIOSFODNN7EXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
         );
 
         let action = CreateBucket::new(&bucket, &credentials);

--- a/src/actions/delete_bucket.rs
+++ b/src/actions/delete_bucket.rs
@@ -91,7 +91,7 @@ mod tests {
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
         let bucket =
-            Bucket::new(endpoint, false, "examplebucket".into(), "us-east-1".into()).unwrap();
+            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
             "AKIAIOSFODNN7EXAMPLE".into(),
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),

--- a/src/actions/delete_bucket.rs
+++ b/src/actions/delete_bucket.rs
@@ -93,8 +93,8 @@ mod tests {
         let bucket =
             Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
-            "AKIAIOSFODNN7EXAMPLE".into(),
-            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
+            "AKIAIOSFODNN7EXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
         );
 
         let action = DeleteBucket::new(&bucket, &credentials);

--- a/src/actions/delete_bucket.rs
+++ b/src/actions/delete_bucket.rs
@@ -90,8 +90,7 @@ mod tests {
         let expires_in = Duration::from_secs(86400);
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
-        let bucket =
-            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
+        let bucket = Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
             "AKIAIOSFODNN7EXAMPLE",
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",

--- a/src/actions/delete_object.rs
+++ b/src/actions/delete_object.rs
@@ -94,8 +94,7 @@ mod tests {
         let expires_in = Duration::from_secs(86400);
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
-        let bucket =
-            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
+        let bucket = Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
             "AKIAIOSFODNN7EXAMPLE",
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
@@ -114,8 +113,7 @@ mod tests {
         let expires_in = Duration::from_secs(86400);
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
-        let bucket =
-            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
+        let bucket = Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
 
         let action = DeleteObject::new(&bucket, None, "test.txt");
         let url = action.sign(expires_in);

--- a/src/actions/delete_object.rs
+++ b/src/actions/delete_object.rs
@@ -95,7 +95,7 @@ mod tests {
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
         let bucket =
-            Bucket::new(endpoint, false, "examplebucket".into(), "us-east-1".into()).unwrap();
+            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
             "AKIAIOSFODNN7EXAMPLE".into(),
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
@@ -115,7 +115,7 @@ mod tests {
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
         let bucket =
-            Bucket::new(endpoint, false, "examplebucket".into(), "us-east-1".into()).unwrap();
+            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
 
         let action = DeleteObject::new(&bucket, None, "test.txt");
         let url = action.sign(expires_in);

--- a/src/actions/delete_object.rs
+++ b/src/actions/delete_object.rs
@@ -97,8 +97,8 @@ mod tests {
         let bucket =
             Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
-            "AKIAIOSFODNN7EXAMPLE".into(),
-            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
+            "AKIAIOSFODNN7EXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
         );
 
         let action = DeleteObject::new(&bucket, Some(&credentials), "test.txt");

--- a/src/actions/get_object.rs
+++ b/src/actions/get_object.rs
@@ -97,8 +97,8 @@ mod tests {
         let bucket =
             Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
-            "AKIAIOSFODNN7EXAMPLE".into(),
-            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
+            "AKIAIOSFODNN7EXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
         );
 
         let action = GetObject::new(&bucket, Some(&credentials), "test.txt");
@@ -123,8 +123,8 @@ mod tests {
         let bucket =
             Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
-            "AKIAIOSFODNN7EXAMPLE".into(),
-            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
+            "AKIAIOSFODNN7EXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
         );
 
         let mut action = GetObject::new(&bucket, Some(&credentials), "test.txt");

--- a/src/actions/get_object.rs
+++ b/src/actions/get_object.rs
@@ -94,8 +94,7 @@ mod tests {
         let expires_in = Duration::from_secs(86400);
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
-        let bucket =
-            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
+        let bucket = Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
             "AKIAIOSFODNN7EXAMPLE",
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
@@ -120,8 +119,7 @@ mod tests {
         let expires_in = Duration::from_secs(86400);
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
-        let bucket =
-            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
+        let bucket = Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
             "AKIAIOSFODNN7EXAMPLE",
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
@@ -143,8 +141,7 @@ mod tests {
         let expires_in = Duration::from_secs(86400);
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
-        let bucket =
-            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
+        let bucket = Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
 
         let mut action = GetObject::new(&bucket, None, "test.txt");
         action

--- a/src/actions/get_object.rs
+++ b/src/actions/get_object.rs
@@ -95,7 +95,7 @@ mod tests {
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
         let bucket =
-            Bucket::new(endpoint, false, "examplebucket".into(), "us-east-1".into()).unwrap();
+            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
             "AKIAIOSFODNN7EXAMPLE".into(),
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
@@ -121,7 +121,7 @@ mod tests {
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
         let bucket =
-            Bucket::new(endpoint, false, "examplebucket".into(), "us-east-1".into()).unwrap();
+            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
             "AKIAIOSFODNN7EXAMPLE".into(),
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
@@ -144,7 +144,7 @@ mod tests {
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
         let bucket =
-            Bucket::new(endpoint, false, "examplebucket".into(), "us-east-1".into()).unwrap();
+            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
 
         let mut action = GetObject::new(&bucket, None, "test.txt");
         action

--- a/src/actions/list_objects_v2.rs
+++ b/src/actions/list_objects_v2.rs
@@ -179,8 +179,8 @@ mod tests {
         let bucket =
             Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
-            "AKIAIOSFODNN7EXAMPLE".into(),
-            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
+            "AKIAIOSFODNN7EXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
         );
 
         let action = ListObjectsV2::new(&bucket, Some(&credentials));

--- a/src/actions/list_objects_v2.rs
+++ b/src/actions/list_objects_v2.rs
@@ -176,8 +176,7 @@ mod tests {
         let expires_in = Duration::from_secs(86400);
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
-        let bucket =
-            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
+        let bucket = Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
             "AKIAIOSFODNN7EXAMPLE",
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
@@ -196,8 +195,7 @@ mod tests {
         let expires_in = Duration::from_secs(86400);
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
-        let bucket =
-            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
+        let bucket = Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
 
         let mut action = ListObjectsV2::new(&bucket, None);
         action.query_mut().insert("continuation-token", "duck");

--- a/src/actions/list_objects_v2.rs
+++ b/src/actions/list_objects_v2.rs
@@ -177,7 +177,7 @@ mod tests {
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
         let bucket =
-            Bucket::new(endpoint, false, "examplebucket".into(), "us-east-1".into()).unwrap();
+            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
             "AKIAIOSFODNN7EXAMPLE".into(),
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
@@ -197,7 +197,7 @@ mod tests {
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
         let bucket =
-            Bucket::new(endpoint, false, "examplebucket".into(), "us-east-1".into()).unwrap();
+            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
 
         let mut action = ListObjectsV2::new(&bucket, None);
         action.query_mut().insert("continuation-token", "duck");

--- a/src/actions/multipart_upload/abort.rs
+++ b/src/actions/multipart_upload/abort.rs
@@ -111,8 +111,8 @@ mod tests {
         let bucket =
             Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
-            "AKIAIOSFODNN7EXAMPLE".into(),
-            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
+            "AKIAIOSFODNN7EXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
         );
 
         let action = AbortMultipartUpload::new(&bucket, Some(&credentials), "test.txt", "abcd");

--- a/src/actions/multipart_upload/abort.rs
+++ b/src/actions/multipart_upload/abort.rs
@@ -109,7 +109,7 @@ mod tests {
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
         let bucket =
-            Bucket::new(endpoint, false, "examplebucket".into(), "us-east-1".into()).unwrap();
+            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
             "AKIAIOSFODNN7EXAMPLE".into(),
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
@@ -129,7 +129,7 @@ mod tests {
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
         let bucket =
-            Bucket::new(endpoint, false, "examplebucket".into(), "us-east-1".into()).unwrap();
+            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
 
         let action = AbortMultipartUpload::new(&bucket, None, "test.txt", "abcd");
         let url = action.sign(expires_in);

--- a/src/actions/multipart_upload/abort.rs
+++ b/src/actions/multipart_upload/abort.rs
@@ -108,8 +108,7 @@ mod tests {
         let expires_in = Duration::from_secs(86400);
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
-        let bucket =
-            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
+        let bucket = Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
             "AKIAIOSFODNN7EXAMPLE",
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
@@ -128,8 +127,7 @@ mod tests {
         let expires_in = Duration::from_secs(86400);
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
-        let bucket =
-            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
+        let bucket = Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
 
         let action = AbortMultipartUpload::new(&bucket, None, "test.txt", "abcd");
         let url = action.sign(expires_in);

--- a/src/actions/multipart_upload/complete.rs
+++ b/src/actions/multipart_upload/complete.rs
@@ -151,8 +151,7 @@ mod tests {
         let expires_in = Duration::from_secs(86400);
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
-        let bucket =
-            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
+        let bucket = Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
             "AKIAIOSFODNN7EXAMPLE",
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
@@ -181,8 +180,7 @@ mod tests {
         let expires_in = Duration::from_secs(86400);
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
-        let bucket =
-            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
+        let bucket = Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
 
         let etags = ["123456789", "abcdef"];
         let action =

--- a/src/actions/multipart_upload/complete.rs
+++ b/src/actions/multipart_upload/complete.rs
@@ -152,7 +152,7 @@ mod tests {
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
         let bucket =
-            Bucket::new(endpoint, false, "examplebucket".into(), "us-east-1".into()).unwrap();
+            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
             "AKIAIOSFODNN7EXAMPLE".into(),
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
@@ -182,7 +182,7 @@ mod tests {
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
         let bucket =
-            Bucket::new(endpoint, false, "examplebucket".into(), "us-east-1".into()).unwrap();
+            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
 
         let etags = ["123456789", "abcdef"];
         let action =

--- a/src/actions/multipart_upload/complete.rs
+++ b/src/actions/multipart_upload/complete.rs
@@ -154,8 +154,8 @@ mod tests {
         let bucket =
             Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
-            "AKIAIOSFODNN7EXAMPLE".into(),
-            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
+            "AKIAIOSFODNN7EXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
         );
 
         let etags = ["123456789", "abcdef"];

--- a/src/actions/multipart_upload/create.rs
+++ b/src/actions/multipart_upload/create.rs
@@ -124,7 +124,7 @@ mod tests {
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
         let bucket =
-            Bucket::new(endpoint, false, "examplebucket".into(), "us-east-1".into()).unwrap();
+            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
             "AKIAIOSFODNN7EXAMPLE".into(),
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
@@ -144,7 +144,7 @@ mod tests {
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
         let bucket =
-            Bucket::new(endpoint, false, "examplebucket".into(), "us-east-1".into()).unwrap();
+            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
 
         let action = CreateMultipartUpload::new(&bucket, None, "test.txt");
         let url = action.sign(expires_in);

--- a/src/actions/multipart_upload/create.rs
+++ b/src/actions/multipart_upload/create.rs
@@ -123,8 +123,7 @@ mod tests {
         let expires_in = Duration::from_secs(86400);
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
-        let bucket =
-            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
+        let bucket = Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
             "AKIAIOSFODNN7EXAMPLE",
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
@@ -143,8 +142,7 @@ mod tests {
         let expires_in = Duration::from_secs(86400);
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
-        let bucket =
-            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
+        let bucket = Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
 
         let action = CreateMultipartUpload::new(&bucket, None, "test.txt");
         let url = action.sign(expires_in);

--- a/src/actions/multipart_upload/create.rs
+++ b/src/actions/multipart_upload/create.rs
@@ -126,8 +126,8 @@ mod tests {
         let bucket =
             Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
-            "AKIAIOSFODNN7EXAMPLE".into(),
-            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
+            "AKIAIOSFODNN7EXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
         );
 
         let action = CreateMultipartUpload::new(&bucket, Some(&credentials), "test.txt");

--- a/src/actions/multipart_upload/upload.rs
+++ b/src/actions/multipart_upload/upload.rs
@@ -128,8 +128,8 @@ mod tests {
         let bucket =
             Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
-            "AKIAIOSFODNN7EXAMPLE".into(),
-            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
+            "AKIAIOSFODNN7EXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
         );
 
         let action = UploadPart::new(&bucket, Some(&credentials), "test.txt", 1, "abcd");

--- a/src/actions/multipart_upload/upload.rs
+++ b/src/actions/multipart_upload/upload.rs
@@ -126,7 +126,7 @@ mod tests {
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
         let bucket =
-            Bucket::new(endpoint, false, "examplebucket".into(), "us-east-1".into()).unwrap();
+            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
             "AKIAIOSFODNN7EXAMPLE".into(),
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
@@ -146,7 +146,7 @@ mod tests {
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
         let bucket =
-            Bucket::new(endpoint, false, "examplebucket".into(), "us-east-1".into()).unwrap();
+            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
 
         let action = UploadPart::new(&bucket, None, "test.txt", 1, "abcd");
         let url = action.sign(expires_in);

--- a/src/actions/multipart_upload/upload.rs
+++ b/src/actions/multipart_upload/upload.rs
@@ -125,8 +125,7 @@ mod tests {
         let expires_in = Duration::from_secs(86400);
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
-        let bucket =
-            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
+        let bucket = Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
             "AKIAIOSFODNN7EXAMPLE",
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
@@ -145,8 +144,7 @@ mod tests {
         let expires_in = Duration::from_secs(86400);
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
-        let bucket =
-            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
+        let bucket = Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
 
         let action = UploadPart::new(&bucket, None, "test.txt", 1, "abcd");
         let url = action.sign(expires_in);

--- a/src/actions/put_object.rs
+++ b/src/actions/put_object.rs
@@ -94,8 +94,7 @@ mod tests {
         let expires_in = Duration::from_secs(86400);
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
-        let bucket =
-            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
+        let bucket = Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
             "AKIAIOSFODNN7EXAMPLE",
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
@@ -114,8 +113,7 @@ mod tests {
         let expires_in = Duration::from_secs(86400);
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
-        let bucket =
-            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
+        let bucket = Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
 
         let action = PutObject::new(&bucket, None, "test.txt");
         let url = action.sign(expires_in);

--- a/src/actions/put_object.rs
+++ b/src/actions/put_object.rs
@@ -97,8 +97,8 @@ mod tests {
         let bucket =
             Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
-            "AKIAIOSFODNN7EXAMPLE".into(),
-            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
+            "AKIAIOSFODNN7EXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
         );
 
         let action = PutObject::new(&bucket, Some(&credentials), "test.txt");

--- a/src/actions/put_object.rs
+++ b/src/actions/put_object.rs
@@ -95,7 +95,7 @@ mod tests {
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
         let bucket =
-            Bucket::new(endpoint, false, "examplebucket".into(), "us-east-1".into()).unwrap();
+            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
         let credentials = Credentials::new(
             "AKIAIOSFODNN7EXAMPLE".into(),
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
@@ -115,7 +115,7 @@ mod tests {
 
         let endpoint = "https://s3.amazonaws.com".parse().unwrap();
         let bucket =
-            Bucket::new(endpoint, false, "examplebucket".into(), "us-east-1".into()).unwrap();
+            Bucket::new(endpoint, false, "examplebucket", "us-east-1").unwrap();
 
         let action = PutObject::new(&bucket, None, "test.txt");
         let url = action.sign(expires_in);

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -49,7 +49,12 @@ pub struct Bucket {
 
 impl Bucket {
     /// Construct a new S3 bucket
-    pub fn new<S: Into<String>>(endpoint: Url, path_style: bool, name: S, region: S) -> Option<Self> {
+    pub fn new<S: Into<String>>(
+        endpoint: Url,
+        path_style: bool,
+        name: S,
+        region: S,
+    ) -> Option<Self> {
         let _ = endpoint.host_str()?;
 
         match endpoint.scheme() {

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -49,20 +49,20 @@ pub struct Bucket {
 
 impl Bucket {
     /// Construct a new S3 bucket
-    pub fn new<S: AsRef<str>>(endpoint: Url, path_style: bool, name: S, region: S) -> Option<Self> {
+    pub fn new<S: Into<String>>(endpoint: Url, path_style: bool, name: S, region: S) -> Option<Self> {
         let _ = endpoint.host_str()?;
 
         match endpoint.scheme() {
             "http" | "https" => {}
             _ => return None,
         };
-
-        let base_url = base_url(endpoint, name.as_ref(), path_style);
+        let name: String = name.into();
+        let base_url = base_url(endpoint, &name, path_style);
 
         Some(Self {
             base_url,
-            name: String::from(name.as_ref()),
-            region: String::from(region.as_ref()),
+            name,
+            region: region.into(),
         })
     }
 

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -49,7 +49,8 @@ pub struct Bucket {
 
 impl Bucket {
     /// Construct a new S3 bucket
-    pub fn new(endpoint: Url, path_style: bool, name: String, region: String) -> Option<Self> {
+    // 这里可以有 pr
+    pub fn new<S: AsRef<str>>(endpoint: Url, path_style: bool, name: S, region: S) -> Option<Self> {
         let _ = endpoint.host_str()?;
 
         match endpoint.scheme() {
@@ -57,12 +58,12 @@ impl Bucket {
             _ => return None,
         };
 
-        let base_url = base_url(endpoint, &name, path_style);
+        let base_url = base_url(endpoint, name.as_ref(), path_style);
 
         Some(Self {
             base_url,
-            name,
-            region,
+            name: String::from(name.as_ref()),
+            region: String::from(region.as_ref()),
         })
     }
 
@@ -234,7 +235,7 @@ mod tests {
             .unwrap();
         let name = "rusty-s3";
         let region = "eu-west-1";
-        let bucket = Bucket::new(endpoint, true, name.into(), region.into()).unwrap();
+        let bucket = Bucket::new(endpoint, true, name, region).unwrap();
 
         assert_eq!(bucket.base_url(), &base_url);
         assert_eq!(bucket.name(), name);
@@ -249,7 +250,7 @@ mod tests {
             .unwrap();
         let name = "rusty-s3";
         let region = "eu-west-1";
-        let bucket = Bucket::new(endpoint, false, name.into(), region.into()).unwrap();
+        let bucket = Bucket::new(endpoint, false, name, region).unwrap();
 
         assert_eq!(bucket.base_url(), &base_url);
         assert_eq!(bucket.name(), name);
@@ -261,7 +262,7 @@ mod tests {
         let endpoint = "file:///home/something".parse().unwrap();
         let name = "rusty-s3";
         let region = "eu-west-1";
-        assert!(Bucket::new(endpoint, true, name.into(), region.into()).is_none());
+        assert!(Bucket::new(endpoint, true, name, region).is_none());
     }
 
     #[test]
@@ -269,7 +270,7 @@ mod tests {
         let endpoint: Url = "https://s3-eu-west-1.amazonaws.com".parse().unwrap();
         let name = "rusty-s3";
         let region = "eu-west-1";
-        let bucket = Bucket::new(endpoint, true, name.into(), region.into()).unwrap();
+        let bucket = Bucket::new(endpoint, true, name, region).unwrap();
 
         let path_style = bucket.object_url("something/cat.jpg").unwrap();
         assert_eq!(
@@ -283,7 +284,7 @@ mod tests {
         let endpoint: Url = "https://s3-eu-west-1.amazonaws.com".parse().unwrap();
         let name = "rusty-s3";
         let region = "eu-west-1";
-        let bucket = Bucket::new(endpoint, false, name.into(), region.into()).unwrap();
+        let bucket = Bucket::new(endpoint, false, name, region).unwrap();
 
         let domain_style = bucket.object_url("something/cat.jpg").unwrap();
         assert_eq!(
@@ -298,7 +299,7 @@ mod tests {
 
         let name = "rusty-s3";
         let region = "eu-west-1";
-        let bucket = Bucket::new(endpoint, true, name.into(), region.into()).unwrap();
+        let bucket = Bucket::new(endpoint, true, name, region).unwrap();
 
         let credentials = Credentials::new(
             "AKIAIOSFODNN7EXAMPLE".into(),

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -49,7 +49,6 @@ pub struct Bucket {
 
 impl Bucket {
     /// Construct a new S3 bucket
-    // 这里可以有 pr
     pub fn new<S: AsRef<str>>(endpoint: Url, path_style: bool, name: S, region: S) -> Option<Self> {
         let _ = endpoint.host_str()?;
 
@@ -302,8 +301,8 @@ mod tests {
         let bucket = Bucket::new(endpoint, true, name, region).unwrap();
 
         let credentials = Credentials::new(
-            "AKIAIOSFODNN7EXAMPLE".into(),
-            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
+            "AKIAIOSFODNN7EXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
         );
 
         let _ = bucket.create_bucket(&credentials);

--- a/src/credentials/mod.rs
+++ b/src/credentials/mod.rs
@@ -29,7 +29,7 @@ pub struct Credentials {
 impl Credentials {
     /// Construct a new `Credentials` using the provided key and secret
     #[inline]
-    pub fn new(key: String, secret: String) -> Self {
+    pub fn new<S: AsRef<str>>(key: S, secret: S) -> Self {
         Self::new_(key, secret, None)
     }
 
@@ -38,8 +38,12 @@ impl Credentials {
     /// For backwards compatibility this method was named `new_`, and will replace
     /// the current `new` implementation in the 0.2.0 release.
     #[inline]
-    pub fn new_(key: String, secret: String, token: Option<String>) -> Self {
-        Self { key, secret, token }
+    pub fn new_<S: AsRef<str>>(key: S, secret: S, token: Option<S>) -> Self {
+        Self {
+            key: String::from(key.as_ref()),
+            secret: secret.as_ref().into(),
+            token: token.map(|s| s.as_ref().into())
+        }
     }
 
     /// Construct a new `Credentials` using AWS's default environment variables
@@ -90,7 +94,7 @@ mod tests {
 
     #[test]
     fn key_secret() {
-        let credentials = Credentials::new("abcd".into(), "1234".into());
+        let credentials = Credentials::new("abcd", "1234");
         assert_eq!(credentials.key(), "abcd");
         assert_eq!(credentials.secret(), "1234");
         assert!(credentials.token().is_none());
@@ -98,7 +102,7 @@ mod tests {
 
     #[test]
     fn key_secret_token() {
-        let credentials = Credentials::new_("abcd".into(), "1234".into(), Some("xyz".into()));
+        let credentials = Credentials::new_("abcd", "1234", Some("xyz"));
         assert_eq!(credentials.key(), "abcd");
         assert_eq!(credentials.secret(), "1234");
         assert_eq!(credentials.token(), Some("xyz"));
@@ -106,14 +110,14 @@ mod tests {
 
     #[test]
     fn debug() {
-        let credentials = Credentials::new("abcd".into(), "1234".into());
+        let credentials = Credentials::new("abcd", "1234");
         let debug_output = format!("{:?}", credentials);
         assert_eq!(debug_output, "Credentials { key: \"abcd\" }");
     }
 
     #[test]
     fn debug_token() {
-        let credentials = Credentials::new_("abcd".into(), "1234".into(), Some("xyz".into()));
+        let credentials = Credentials::new_("abcd", "1234", Some("xyz"));
         let debug_output = format!("{:?}", credentials);
         assert_eq!(debug_output, "Credentials { key: \"abcd\" }");
     }

--- a/src/credentials/mod.rs
+++ b/src/credentials/mod.rs
@@ -29,7 +29,7 @@ pub struct Credentials {
 impl Credentials {
     /// Construct a new `Credentials` using the provided key and secret
     #[inline]
-    pub fn new<S: AsRef<str>>(key: S, secret: S) -> Self {
+    pub fn new<S: Into<String>>(key: S, secret: S) -> Self {
         Self::new_(key, secret, None)
     }
 
@@ -38,11 +38,11 @@ impl Credentials {
     /// For backwards compatibility this method was named `new_`, and will replace
     /// the current `new` implementation in the 0.2.0 release.
     #[inline]
-    pub fn new_<S: AsRef<str>>(key: S, secret: S, token: Option<S>) -> Self {
+    pub fn new_<S: Into<String>>(key: S, secret: S, token: Option<S>) -> Self {
         Self {
-            key: String::from(key.as_ref()),
-            secret: secret.as_ref().into(),
-            token: token.map(|s| s.as_ref().into()),
+            key: key.into(),
+            secret: secret.into(),
+            token: token.map(|s| s.into()),
         }
     }
 

--- a/src/credentials/mod.rs
+++ b/src/credentials/mod.rs
@@ -42,7 +42,7 @@ impl Credentials {
         Self {
             key: String::from(key.as_ref()),
             secret: secret.as_ref().into(),
-            token: token.map(|s| s.as_ref().into())
+            token: token.map(|s| s.as_ref().into()),
         }
     }
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -17,7 +17,7 @@ pub async fn bucket() -> (Bucket, Credentials, Client) {
     let region = "minio";
 
     let bucket = Bucket::new(url, true, name, region.into()).unwrap();
-    let credentials = Credentials::new(key.into(), secret.into());
+    let credentials = Credentials::new(key, secret);
 
     let client = Client::new();
     let action = CreateBucket::new(&bucket, &credentials);


### PR DESCRIPTION
For the Bucket::new() func, I think the better implementation is use the generic `S: AsRef<str>`, which will improve the experience of the users using this crate, because they can specify the parameters with both the `String` and `&str`.  
So I create this pull request.  
hope for being merged, thanks.  