### PR TITLE
Introduce the 'full' feature

### DIFF
--- a/.github/workflows/continuos-integration.yml
+++ b/.github/workflows/continuos-integration.yml
@@ -16,7 +16,7 @@ jobs:
         rustup update --no-self-update stable
         rustup component add rustfmt
 
-    - name: Run clippy
+    - name: Run fmt
       run: cargo fmt -- --check
 
   clippy:
@@ -63,6 +63,9 @@ jobs:
     - name: Run tests
       if: matrix.platform != 'ubuntu-20.04'
       run: cargo test --lib
+
+    - name: Run tests no default features
+      run: cargo test --lib --no-default-features
 
   msrv:
     runs-on: ubuntu-20.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,17 @@ sha2 = "0.9.2"
 time = { version = "0.3", default-features = false, features = ["macros", "formatting", "parsing"] }
 url = "2.2.0"
 percent-encoding = "2.1.0"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-quick-xml = { version = "0.22", features = ["serialize"] }
-md5 = "0.7"
-base64 = "0.13"
+
+# optional
+base64 = { version = "0.13", optional = true }
+quick-xml = { version = "0.22", features = ["serialize"], optional = true }
+md5 = { version = "0.7", optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
+serde_json = { version = "1", optional = true }
+
+[features]
+default = ["full"]
+full = ["base64", "quick-xml", "md5", "serde", "serde_json"]
 
 [dev-dependencies]
 tokio = { version = "1.0.1", features = ["macros", "fs", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 hmac = "0.11"
 sha2 = "0.9.2"
-time = { version = "0.3", default-features = false, features = ["macros", "formatting", "parsing"] }
+time = { version = "0.3", default-features = false, features = ["macros", "formatting"] }
 url = "2.2.0"
 percent-encoding = "2.1.0"
 
@@ -26,7 +26,7 @@ serde_json = { version = "1", optional = true }
 
 [features]
 default = ["full"]
-full = ["base64", "quick-xml", "md5", "serde", "serde_json"]
+full = ["base64", "quick-xml", "md5", "serde", "serde_json", "time/parsing"]
 
 [dev-dependencies]
 tokio = { version = "1.0.1", features = ["macros", "fs", "rt-multi-thread"] }

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -7,14 +7,19 @@ use url::Url;
 pub use self::create_bucket::CreateBucket;
 pub use self::delete_bucket::DeleteBucket;
 pub use self::delete_object::DeleteObject;
+#[cfg(feature = "full")]
 pub use self::delete_objects::{DeleteObjects, ObjectIdentifier};
 pub use self::get_object::GetObject;
 pub use self::head_object::HeadObject;
+#[cfg(feature = "full")]
 #[doc(inline)]
 pub use self::list_objects_v2::{ListObjectsV2, ListObjectsV2Response};
 pub use self::multipart_upload::abort::AbortMultipartUpload;
+#[cfg(feature = "full")]
 pub use self::multipart_upload::complete::CompleteMultipartUpload;
+#[cfg(feature = "full")]
 pub use self::multipart_upload::create::CreateMultipartUpload;
+#[cfg(feature = "full")]
 pub use self::multipart_upload::list_parts::{ListParts, ListPartsResponse};
 pub use self::multipart_upload::upload::UploadPart;
 pub use self::put_object::PutObject;
@@ -23,9 +28,11 @@ use crate::{Map, Method};
 mod create_bucket;
 mod delete_bucket;
 mod delete_object;
+#[cfg(feature = "full")]
 mod delete_objects;
 mod get_object;
 mod head_object;
+#[cfg(feature = "full")]
 pub mod list_objects_v2;
 mod multipart_upload;
 mod put_object;

--- a/src/actions/multipart_upload/mod.rs
+++ b/src/actions/multipart_upload/mod.rs
@@ -1,5 +1,8 @@
 pub mod abort;
+#[cfg(feature = "full")]
 pub mod complete;
+#[cfg(feature = "full")]
 pub mod create;
+#[cfg(feature = "full")]
 pub mod list_parts;
 pub mod upload;

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -4,9 +4,12 @@ use std::fmt::{self, Display};
 use url::{ParseError, Url};
 
 use crate::actions::{
-    AbortMultipartUpload, CompleteMultipartUpload, CreateBucket, CreateMultipartUpload,
-    DeleteBucket, DeleteObject, DeleteObjects, GetObject, HeadObject, ListObjectsV2, ListParts,
+    AbortMultipartUpload, CreateBucket, DeleteBucket, DeleteObject, GetObject, HeadObject,
     PutObject, UploadPart,
+};
+#[cfg(feature = "full")]
+use crate::actions::{
+    CompleteMultipartUpload, CreateMultipartUpload, DeleteObjects, ListObjectsV2, ListParts,
 };
 use crate::signing::util::percent_encode_path;
 use crate::Credentials;
@@ -181,6 +184,7 @@ impl Bucket {
     /// List all objects in the bucket.
     ///
     /// See [`ListObjectsV2`] for more details.
+    #[cfg(feature = "full")]
     pub fn list_objects_v2<'a>(
         &'a self,
         credentials: Option<&'a Credentials>,
@@ -213,6 +217,7 @@ impl Bucket {
     /// Delete multiple objects from S3 using a single `POST` request.
     ///
     /// See [`DeleteObjects`] for more details.
+    #[cfg(feature = "full")]
     pub fn delete_objects<'a, I>(
         &'a self,
         credentials: Option<&'a Credentials>,
@@ -228,6 +233,7 @@ impl Bucket {
     /// Create a multipart upload.
     ///
     /// See [`CreateMultipartUpload`] for more details.
+    #[cfg(feature = "full")]
     pub fn create_multipart_upload<'a>(
         &'a self,
         credentials: Option<&'a Credentials>,
@@ -252,6 +258,7 @@ impl Bucket {
     /// Complete a multipart upload.
     ///
     /// See [`CompleteMultipartUpload`] for more details.
+    #[cfg(feature = "full")]
     pub fn complete_multipart_upload<'a, I>(
         &'a self,
         credentials: Option<&'a Credentials>,
@@ -277,6 +284,7 @@ impl Bucket {
     /// Lists the parts that have been uploaded for a specific multipart upload.
     ///
     /// See [`ListParts`] for more details.
+    #[cfg(feature = "full")]
     pub fn list_parts<'a>(
         &'a self,
         credentials: Option<&'a Credentials>,
@@ -300,10 +308,11 @@ impl StdError for BucketError {}
 
 #[cfg(test)]
 mod tests {
-    use crate::actions::ObjectIdentifier;
     use pretty_assertions::assert_eq;
 
     use super::*;
+    #[cfg(feature = "full")]
+    use crate::actions::ObjectIdentifier;
 
     #[test]
     fn new_pathstyle() {
@@ -413,13 +422,17 @@ mod tests {
 
         let _ = bucket.head_object(Some(&credentials), "duck.jpg");
         let _ = bucket.get_object(Some(&credentials), "duck.jpg");
+        #[cfg(feature = "full")]
         let _ = bucket.list_objects_v2(Some(&credentials));
         let _ = bucket.put_object(Some(&credentials), "duck.jpg");
         let _ = bucket.delete_object(Some(&credentials), "duck.jpg");
+        #[cfg(feature = "full")]
         let _ = bucket.delete_objects(Some(&credentials), std::iter::empty::<ObjectIdentifier>());
 
+        #[cfg(feature = "full")]
         let _ = bucket.create_multipart_upload(Some(&credentials), "duck.jpg");
         let _ = bucket.upload_part(Some(&credentials), "duck.jpg", 1, "abcd");
+        #[cfg(feature = "full")]
         let _ = bucket.complete_multipart_upload(
             Some(&credentials),
             "duck.jpg",
@@ -427,6 +440,7 @@ mod tests {
             ["1234"].iter().copied(),
         );
         let _ = bucket.abort_multipart_upload(Some(&credentials), "duck.jpg", "abcd");
+        #[cfg(feature = "full")]
         let _ = bucket.list_parts(Some(&credentials), "duck.jpg", "abcd");
     }
 }

--- a/src/credentials/mod.rs
+++ b/src/credentials/mod.rs
@@ -13,9 +13,11 @@ use std::env;
 use std::fmt::{self, Debug, Formatter};
 
 pub use self::rotating::RotatingCredentials;
+#[cfg(feature = "full")]
 pub use self::serde::Ec2SecurityCredentialsMetadataResponse;
 
 mod rotating;
+#[cfg(feature = "full")]
 mod serde;
 
 /// S3 credentials

--- a/src/time_.rs
+++ b/src/time_.rs
@@ -3,6 +3,7 @@ use time::macros::format_description;
 
 pub const ISO8601: &[FormatItem<'static>] =
     format_description!("[year][month][day]T[hour][minute][second]Z");
+#[cfg(feature = "full")]
 pub const ISO8601_EXT: &[FormatItem<'static>] =
     format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]Z");
 pub const YYYYMMDD: &[FormatItem<'static>] = format_description!("[year][month][day]");


### PR DESCRIPTION
Part of the reason why rusty-s3 was created is to have a faster to compile alternative to other s3 clients. Unfortunately adding more actions also meant having to add more dependencies.

This adds the enabled by default `full` feature, which can in the future be split into smaller features without making breaking changes, which makes it possible to disable the more complicated methods and only have to compile the simpler ones. This in turn reduces the number of dependencies