### PR TITLE
Use time 0.3.9 in the MSRV job

### DIFF
--- a/.github/workflows/continuos-integration.yml
+++ b/.github/workflows/continuos-integration.yml
@@ -78,8 +78,9 @@ jobs:
     - name: Install Rust
       run: rustup default 1.56
 
-    - name: Remove unused dev-dependencies breaking MSRV
+    - name: Fix dependencies breaking MSRV
       run: |
+        cargo update -p time --precise 0.3.9
         sed -i '/tokio/d' Cargo.toml
         sed -i '/reqwest/d' Cargo.toml
 


### PR DESCRIPTION
Seeing that time 0.3.10 bumped MSRV to 1.57 and we don't need any of the newer Rust features I think for the moment we could try to make the MSRV job run on the last version still supporting 1.56