### PR TITLE
Optional max keys

### DIFF
--- a/src/actions/list_objects_v2.rs
+++ b/src/actions/list_objects_v2.rs
@@ -284,7 +284,7 @@ mod tests {
         assert_eq!(item_3.size, 41259);
         assert_eq!(item_3.storage_class, Some("STANDARD".to_string()));
 
-        assert_eq!(parsed.max_keys, 4500);
+        assert_eq!(parsed.max_keys, Some(4500));
         assert!(parsed.common_prefixes.is_empty());
         assert!(parsed.next_continuation_token.is_none());
         assert!(parsed.start_after.is_none());
@@ -308,7 +308,7 @@ mod tests {
         let parsed = ListObjectsV2::parse_response(input).unwrap();
         assert_eq!(parsed.contents.is_empty(), true);
 
-        assert_eq!(parsed.max_keys, 4500);
+        assert_eq!(parsed.max_keys, Some(4500));
         assert!(parsed.common_prefixes.is_empty());
         assert!(parsed.next_continuation_token.is_none());
         assert!(parsed.start_after.is_none());

--- a/src/actions/list_objects_v2.rs
+++ b/src/actions/list_objects_v2.rs
@@ -43,7 +43,7 @@ pub struct ListObjectsV2Response {
     // #[serde(rename = "Delimiter")]
     // delimiter: String,
     #[serde(rename = "MaxKeys")]
-    pub max_keys: u16,
+    pub max_keys: Option<u16>,
     #[serde(rename = "CommonPrefixes", default)]
     pub common_prefixes: Vec<CommonPrefixes>,
     // #[serde(rename = "EncodingType")]

--- a/tests/upload_download.rs
+++ b/tests/upload_download.rs
@@ -22,7 +22,7 @@ async fn test1() {
 
     assert!(list.contents.is_empty());
 
-    assert_eq!(list.max_keys, 4500);
+    assert_eq!(list.max_keys, Some(4500));
     assert!(list.common_prefixes.is_empty());
     assert!(list.next_continuation_token.is_none());
     assert!(list.start_after.is_none());
@@ -92,7 +92,7 @@ async fn test_headers() {
 
     assert!(list.contents.is_empty());
 
-    assert_eq!(list.max_keys, 4500);
+    assert_eq!(list.max_keys, Some(4500));
     assert!(list.common_prefixes.is_empty());
     assert!(list.next_continuation_token.is_none());
     assert!(list.start_after.is_none());


### PR DESCRIPTION
S3 backend http://storage.googleapis.com/ does not return `MaxKeys`.

So, it's useful if the field is optional.