### PR TITLE
add wasm-bindgen feature that activates the time crate's wasm-bindgen feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = { version = "1", optional = true }
 
 [features]
 default = ["full"]
+wasm_bindgen = ["time/wasm-bindgen"]
 full = ["dep:base64", "dep:quick-xml", "dep:md-5", "dep:serde", "dep:serde_json", "time/parsing"]
 
 [dev-dependencies]


### PR DESCRIPTION
This is useful, because functions such as Utc::now() don't work in webassembly imported on nodejs otherwise.

(I'm presently working around this by using the sign_with_time function)