### PR TITLE
Allow getting the policy of a bucket

### DIFF
--- a/src/actions/create_bucket.rs
+++ b/src/actions/create_bucket.rs
@@ -50,7 +50,7 @@ impl<'a> S3Action<'a> for CreateBucket<'a> {
 
         sign(
             time,
-            Method::Put,
+            Self::METHOD,
             url,
             self.credentials.key(),
             self.credentials.secret(),

--- a/src/actions/delete_bucket.rs
+++ b/src/actions/delete_bucket.rs
@@ -52,7 +52,7 @@ impl<'a> S3Action<'a> for DeleteBucket<'a> {
 
         sign(
             time,
-            Method::Delete,
+            Self::METHOD,
             url,
             self.credentials.key(),
             self.credentials.secret(),

--- a/src/actions/delete_object.rs
+++ b/src/actions/delete_object.rs
@@ -54,7 +54,7 @@ impl<'a> S3Action<'a> for DeleteObject<'a> {
         match self.credentials {
             Some(credentials) => sign(
                 time,
-                Method::Delete,
+                Self::METHOD,
                 url,
                 credentials.key(),
                 credentials.secret(),

--- a/src/actions/delete_objects.rs
+++ b/src/actions/delete_objects.rs
@@ -135,7 +135,7 @@ where
         match self.credentials {
             Some(credentials) => sign(
                 time,
-                Method::Post,
+                Self::METHOD,
                 url,
                 credentials.key(),
                 credentials.secret(),

--- a/src/actions/get_bucket_policy.rs
+++ b/src/actions/get_bucket_policy.rs
@@ -1,0 +1,129 @@
+use std::iter;
+use std::time::Duration;
+
+use serde::Deserialize;
+use time::OffsetDateTime;
+use url::Url;
+
+use super::S3Action;
+use crate::actions::Method;
+use crate::signing::sign;
+use crate::sorting_iter::SortingIterator;
+use crate::{Bucket, Credentials, Map};
+
+const POLICY_PARAM: &str = "policy";
+
+/// Retrieve a bucket's policy from S3.
+///
+/// Find out more about `GetBucketPolicy` from the [AWS API Reference][api]
+///
+/// [api]: https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketPolicy.html
+#[derive(Debug, Clone)]
+pub struct GetBucketPolicy<'a> {
+    bucket: &'a Bucket,
+    credentials: Option<&'a Credentials>,
+
+    query: Map<'a>,
+    headers: Map<'a>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct GetBucketPolicyResponse {
+    #[serde(rename = "Version")]
+    pub version: String,
+    #[serde(rename = "Id")]
+    pub id: Option<String>,
+}
+
+impl<'a> GetBucketPolicy<'a> {
+    #[inline]
+    pub fn new(bucket: &'a Bucket, credentials: Option<&'a Credentials>) -> Self {
+        Self {
+            bucket,
+            credentials,
+
+            query: Map::new(),
+            headers: Map::new(),
+        }
+    }
+
+    pub fn parse_response(s: &str) -> Result<GetBucketPolicyResponse, serde_json::Error> {
+        serde_json::from_str(s)
+    }
+}
+
+impl<'a> S3Action<'a> for GetBucketPolicy<'a> {
+    const METHOD: Method = Method::Get;
+
+    fn query_mut(&mut self) -> &mut Map<'a> {
+        &mut self.query
+    }
+
+    fn headers_mut(&mut self) -> &mut Map<'a> {
+        &mut self.headers
+    }
+
+    fn sign_with_time(&self, expires_in: Duration, time: &OffsetDateTime) -> Url {
+        let url = self.bucket.base_url().clone();
+        let query = SortingIterator::new(iter::once((POLICY_PARAM, "")), self.query.iter());
+
+        match self.credentials {
+            Some(credentials) => sign(
+                time,
+                Self::METHOD,
+                url,
+                credentials.key(),
+                credentials.secret(),
+                credentials.token(),
+                self.bucket.region(),
+                expires_in.as_secs(),
+                query,
+                self.headers.iter(),
+            ),
+            None => crate::signing::util::add_query_params(url, self.query.iter()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn aws_example() -> Result<(), serde_json::Error> {
+        assert_eq!(
+            GetBucketPolicy::parse_response(r#"{"Version":"1"}"#)?,
+            GetBucketPolicyResponse {
+                version: "1".to_string(),
+                id: None
+            }
+        );
+
+        let content = r#"{
+"Version":"2008-10-17",
+"Id":"aaaa-bbbb-cccc-dddd",
+"Statement" : [
+    {
+        "Effect":"Deny",
+        "Sid":"1", 
+        "Principal" : {
+            "AWS":["111122223333","444455556666"]
+        },
+        "Action":["s3:*"],
+        "Resource":"arn:aws:s3:::bucket/*"
+    }
+] 
+}
+"#;
+        assert_eq!(
+            GetBucketPolicy::parse_response(content)?,
+            GetBucketPolicyResponse {
+                version: "2008-10-17".to_string(),
+                id: Some("aaaa-bbbb-cccc-dddd".to_string()),
+            }
+        );
+        Ok(())
+    }
+}

--- a/src/actions/get_object.rs
+++ b/src/actions/get_object.rs
@@ -54,7 +54,7 @@ impl<'a> S3Action<'a> for GetObject<'a> {
         match self.credentials {
             Some(credentials) => sign(
                 time,
-                Method::Get,
+                Self::METHOD,
                 url,
                 credentials.key(),
                 credentials.secret(),

--- a/src/actions/head_bucket.rs
+++ b/src/actions/head_bucket.rs
@@ -52,7 +52,7 @@ impl<'a> S3Action<'a> for HeadBucket<'a> {
         match self.credentials {
             Some(credentials) => sign(
                 time,
-                Method::Head,
+                Self::METHOD,
                 url,
                 credentials.key(),
                 credentials.secret(),

--- a/src/actions/head_object.rs
+++ b/src/actions/head_object.rs
@@ -54,7 +54,7 @@ impl<'a> S3Action<'a> for HeadObject<'a> {
         match self.credentials {
             Some(credentials) => sign(
                 time,
-                Method::Head,
+                Self::METHOD,
                 url,
                 credentials.key(),
                 credentials.secret(),

--- a/src/actions/list_objects_v2.rs
+++ b/src/actions/list_objects_v2.rs
@@ -208,7 +208,7 @@ impl<'a> S3Action<'a> for ListObjectsV2<'a> {
         match self.credentials {
             Some(credentials) => sign(
                 time,
-                Method::Get,
+                Self::METHOD,
                 url,
                 credentials.key(),
                 credentials.secret(),

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -9,6 +9,8 @@ pub use self::delete_bucket::DeleteBucket;
 pub use self::delete_object::DeleteObject;
 #[cfg(feature = "full")]
 pub use self::delete_objects::{DeleteObjects, ObjectIdentifier};
+#[cfg(feature = "full")]
+pub use self::get_bucket_policy::{GetBucketPolicy, GetBucketPolicyResponse};
 pub use self::get_object::GetObject;
 pub use self::head_bucket::HeadBucket;
 pub use self::head_object::HeadObject;
@@ -31,6 +33,8 @@ mod delete_bucket;
 mod delete_object;
 #[cfg(feature = "full")]
 mod delete_objects;
+#[cfg(feature = "full")]
+mod get_bucket_policy;
 mod get_object;
 mod head_bucket;
 mod head_object;

--- a/src/actions/multipart_upload/abort.rs
+++ b/src/actions/multipart_upload/abort.rs
@@ -68,7 +68,7 @@ impl<'a> S3Action<'a> for AbortMultipartUpload<'a> {
         match self.credentials {
             Some(credentials) => sign(
                 time,
-                Method::Delete,
+                Self::METHOD,
                 url,
                 credentials.key(),
                 credentials.secret(),

--- a/src/actions/multipart_upload/complete.rs
+++ b/src/actions/multipart_upload/complete.rs
@@ -111,7 +111,7 @@ where
         match self.credentials {
             Some(credentials) => sign(
                 time,
-                Method::Post,
+                Self::METHOD,
                 url,
                 credentials.key(),
                 credentials.secret(),

--- a/src/actions/multipart_upload/create.rs
+++ b/src/actions/multipart_upload/create.rs
@@ -83,7 +83,7 @@ impl<'a> S3Action<'a> for CreateMultipartUpload<'a> {
         match self.credentials {
             Some(credentials) => sign(
                 time,
-                Method::Post,
+                Self::METHOD,
                 url,
                 credentials.key(),
                 credentials.secret(),

--- a/src/actions/multipart_upload/list_parts.rs
+++ b/src/actions/multipart_upload/list_parts.rs
@@ -112,7 +112,7 @@ impl<'a> S3Action<'a> for ListParts<'a> {
         match self.credentials {
             Some(credentials) => sign(
                 time,
-                Method::Get,
+                Self::METHOD,
                 url,
                 credentials.key(),
                 credentials.secret(),

--- a/src/actions/multipart_upload/upload.rs
+++ b/src/actions/multipart_upload/upload.rs
@@ -85,7 +85,7 @@ impl<'a> S3Action<'a> for UploadPart<'a> {
         match self.credentials {
             Some(credentials) => sign(
                 time,
-                Method::Put,
+                Self::METHOD,
                 url,
                 credentials.key(),
                 credentials.secret(),

--- a/src/actions/put_object.rs
+++ b/src/actions/put_object.rs
@@ -54,7 +54,7 @@ impl<'a> S3Action<'a> for PutObject<'a> {
         match self.credentials {
             Some(credentials) => sign(
                 time,
-                Method::Put,
+                Self::METHOD,
                 url,
                 credentials.key(),
                 credentials.secret(),

--- a/src/map.rs
+++ b/src/map.rs
@@ -36,7 +36,15 @@ impl<'a> Map<'a> {
 
     /// Insert a new element in this `Map`
     ///
-    /// Overwrites elements with the same `key`, if present.
+    /// If the `key` is already present, the `value` is appended to the existing value:
+    ///
+    /// ```
+    /// let mut map = rusty_s3::Map::new();
+    /// map.insert("k", "a");
+    /// assert_eq!(map.get("k"), Some("a"));
+    /// map.insert("k", "b");
+    /// assert_eq!(map.get("k"), Some("a, b"));
+    /// ```
     pub fn insert<K, V>(&mut self, key: K, value: V)
     where
         K: Into<Cow<'a, str>>,


### PR DESCRIPTION
The struct used to deserialize the response content is very limited, has only the `version` and `id` fields, but it's a good start nevertheless.

Threw in two other small commits, please review each commit separately. Thanks!