### PR TITLE
refactor: migrate XML (de)serialization from quick-xml to instant-xml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,6 +790,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant-xml"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "982b1387d9aeeb637f5a7dab9fcf42c3727bcc0dd3fe01da587aadc8c457ba26"
+dependencies = [
+ "instant-xml-macros",
+ "thiserror",
+ "xmlparser",
+]
+
+[[package]]
+name = "instant-xml-macros"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44127a3a387c070ef0656a6ce53dd0e616cf8d6cf5b159aa478cfd49e1c166e0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,16 +1120,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.39.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
-dependencies = [
- "memchr",
- "serde",
 ]
 
 [[package]]
@@ -1421,11 +1434,11 @@ dependencies = [
  "getrandom 0.4.2",
  "hex",
  "hmac",
+ "instant-xml",
  "jiff",
  "md-5",
  "percent-encoding",
  "pretty_assertions",
- "quick-xml",
  "reqwest",
  "serde",
  "serde_json",
@@ -2320,6 +2333,12 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,15 +22,15 @@ zeroize = "1"
 
 # optional
 base64 = { version = "0.22", optional = true }
+instant-xml = { version = "0.7", optional = true }
 md-5 = { version = "0.11", optional = true }
-quick-xml = { version = "0.39", features = ["serialize"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 
 [features]
 default = ["full"]
 wasm_bindgen = ["jiff/js"]
-full = ["dep:base64", "dep:quick-xml", "dep:md-5", "dep:serde", "dep:serde_json", "jiff/serde"]
+full = ["dep:base64", "dep:instant-xml", "dep:md-5", "dep:serde", "dep:serde_json", "jiff/serde"]
 
 [dev-dependencies]
 tokio = { version = "1.0.1", features = ["macros", "fs", "rt-multi-thread"] }

--- a/src/actions/delete_objects.rs
+++ b/src/actions/delete_objects.rs
@@ -1,13 +1,12 @@
 use std::iter;
 use std::time::Duration;
 
+use instant_xml::{FromXml, ToXml};
 use jiff::Timestamp;
 use md5::{Digest as _, Md5};
-use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::actions::Method;
-use crate::actions::S3Action;
+use crate::actions::{Method, S3_XML_NS, S3Action};
 use crate::signing::sign;
 use crate::sorting_iter::SortingIterator;
 use crate::{Bucket, Credentials, Map};
@@ -66,35 +65,37 @@ impl ObjectIdentifier {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, FromXml)]
+#[xml(rename = "DeleteResult", ns(S3_XML_NS))]
 pub struct DeleteObjectsResponse {
-    #[serde(rename = "Deleted", default)]
     pub deleted: Vec<DeletedObject>,
-    #[serde(rename = "Error", default)]
+    #[xml(rename = "Error")]
     pub errors: Vec<ErrorObject>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, FromXml)]
+#[xml(rename = "Deleted", ns(S3_XML_NS))]
 pub struct DeletedObject {
-    #[serde(rename = "Key")]
+    #[xml(rename = "Key")]
     pub key: String,
-    #[serde(rename = "VersionId")]
+    #[xml(rename = "VersionId")]
     pub version_id: Option<String>,
-    #[serde(rename = "DeleteMarker")]
+    #[xml(rename = "DeleteMarker")]
     pub delete_marker: Option<bool>,
-    #[serde(rename = "DeleteMarkerVersionId")]
+    #[xml(rename = "DeleteMarkerVersionId")]
     pub delete_marker_version_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, FromXml)]
+#[xml(rename = "Error", ns(S3_XML_NS))]
 pub struct ErrorObject {
-    #[serde(rename = "Key")]
+    #[xml(rename = "Key")]
     pub key: String,
-    #[serde(rename = "VersionId")]
+    #[xml(rename = "VersionId")]
     pub version_id: Option<String>,
-    #[serde(rename = "Code")]
+    #[xml(rename = "Code")]
     pub code: String,
-    #[serde(rename = "Message")]
+    #[xml(rename = "Message")]
     pub message: String,
 }
 
@@ -104,8 +105,8 @@ impl DeleteObjectsResponse {
     /// # Errors
     ///
     /// Returns an error if the XML response could not be parsed.
-    pub fn parse(s: impl AsRef<[u8]>) -> Result<Self, quick_xml::DeError> {
-        quick_xml::de::from_reader(s.as_ref())
+    pub fn parse(s: &str) -> Result<Self, instant_xml::Error> {
+        instant_xml::from_str(s)
     }
 }
 
@@ -117,46 +118,38 @@ where
     ///
     /// # Panics
     ///
-    /// Panics if an index is not representable as a `u16`.
+    /// Panics if XML serialization fails, which shouldn't happen in practice.
     pub fn body_with_md5(self) -> (String, String) {
-        #[derive(Serialize)]
-        #[serde(rename = "Delete")]
-        struct DeleteSerde<'a> {
-            #[serde(rename = "Object")]
+        #[derive(ToXml)]
+        #[xml(rename = "Delete")]
+        struct DeleteBody<'a> {
             objects: Vec<Object<'a>>,
-            #[serde(rename = "Quiet")]
+            #[xml(rename = "Quiet")]
             quiet: Option<bool>,
         }
-        #[derive(Serialize)]
-        #[serde(rename = "Delete")]
+        #[derive(ToXml)]
+        #[xml(rename = "Object")]
         struct Object<'a> {
-            #[serde(rename = "$value")]
-            nodes: Vec<Node<'a>>,
-        }
-
-        #[derive(Serialize)]
-        enum Node<'a> {
-            Key(&'a str),
-            VersionId(&'a str),
+            #[xml(rename = "Key")]
+            key: &'a str,
+            #[xml(rename = "VersionId")]
+            version_id: Option<&'a str>,
         }
 
         let objects: Vec<Object<'a>> = self
             .objects
-            .map(|o| {
-                let mut nodes = vec![Node::Key(o.key.as_str())];
-                if let Some(version_id) = &o.version_id {
-                    nodes.push(Node::VersionId(version_id.as_str()));
-                }
-                Object { nodes }
+            .map(|o| Object {
+                key: o.key.as_str(),
+                version_id: o.version_id.as_deref(),
             })
             .collect();
 
-        let req = DeleteSerde {
+        let req = DeleteBody {
             objects,
             quiet: self.quiet.then_some(true),
         };
 
-        let body = quick_xml::se::to_string(&req).unwrap();
+        let body = instant_xml::to_string(&req).unwrap();
 
         let content_md5 = crate::base64::encode(Md5::digest(body.as_bytes()));
         (body, content_md5)
@@ -276,8 +269,7 @@ mod tests {
 
     #[test]
     fn parse_response_success() {
-        let input = r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+        let input = r#"<?xml version="1.0" encoding="UTF-8"?>
         <DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
             <Deleted>
                 <Key>duck.jpg</Key>
@@ -313,8 +305,7 @@ mod tests {
 
     #[test]
     fn parse_response_errors() {
-        let input = r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+        let input = r#"<?xml version="1.0" encoding="UTF-8"?>
         <DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
             <Error>
                 <Key>idk.txt</Key>

--- a/src/actions/list_objects_v2.rs
+++ b/src/actions/list_objects_v2.rs
@@ -1,13 +1,11 @@
 use std::borrow::Cow;
-use std::io::{BufReader, Read};
 use std::time::Duration;
 
+use instant_xml::FromXml;
 use jiff::Timestamp;
-use serde::Deserialize;
 use url::Url;
 
-use crate::actions::Method;
-use crate::actions::S3Action;
+use crate::actions::{Method, S3_XML_NS, S3Action};
 use crate::signing::sign;
 use crate::{Bucket, Credentials, Map};
 
@@ -32,63 +30,49 @@ pub struct ListObjectsV2<'a> {
 }
 
 #[allow(clippy::module_name_repetitions)]
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, FromXml)]
+#[xml(rename = "ListBucketResult", ns(S3_XML_NS))]
 pub struct ListObjectsV2Response {
-    // #[serde(rename = "IsTruncated")]
-    // is_truncated: bool,
-    #[serde(rename = "Contents")]
-    #[serde(default)]
     pub contents: Vec<ListObjectsContent>,
 
-    // #[serde(rename = "Name")]
-    // name: String,
-    // #[serde(rename = "Prefix")]
-    // prefix: String,
-    // #[serde(rename = "Delimiter")]
-    // delimiter: String,
-    #[serde(rename = "MaxKeys")]
+    #[xml(rename = "MaxKeys")]
     pub max_keys: Option<u16>,
-    #[serde(rename = "CommonPrefixes", default)]
     pub common_prefixes: Vec<CommonPrefixes>,
-    // #[serde(rename = "EncodingType")]
-    // encoding_type: String,
-    // #[serde(rename = "KeyCount")]
-    // key_count: u16,
-    // #[serde(rename = "ContinuationToken")]
-    // continuation_token: Option<String>,
-    #[serde(rename = "NextContinuationToken")]
+    #[xml(rename = "NextContinuationToken")]
     pub next_continuation_token: Option<String>,
-    #[serde(rename = "StartAfter")]
+    #[xml(rename = "StartAfter")]
     pub start_after: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, FromXml)]
+#[xml(rename = "Contents", ns(S3_XML_NS))]
 pub struct ListObjectsContent {
-    #[serde(rename = "ETag")]
+    #[xml(rename = "ETag")]
     pub etag: String,
-    #[serde(rename = "Key")]
+    #[xml(rename = "Key")]
     pub key: String,
-    #[serde(rename = "LastModified")]
+    #[xml(rename = "LastModified")]
     pub last_modified: String,
-    #[serde(rename = "Owner")]
     pub owner: Option<ListObjectsOwner>,
-    #[serde(rename = "Size")]
+    #[xml(rename = "Size")]
     pub size: u64,
-    #[serde(rename = "StorageClass")]
+    #[xml(rename = "StorageClass")]
     pub storage_class: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, FromXml)]
+#[xml(rename = "Owner", ns(S3_XML_NS))]
 pub struct ListObjectsOwner {
-    #[serde(rename = "ID")]
+    #[xml(rename = "ID")]
     pub id: String,
-    #[serde(rename = "DisplayName", default)]
-    pub display_name: String,
+    #[xml(rename = "DisplayName")]
+    pub display_name: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, FromXml)]
+#[xml(rename = "CommonPrefixes", ns(S3_XML_NS))]
 pub struct CommonPrefixes {
-    #[serde(rename = "Prefix")]
+    #[xml(rename = "Prefix")]
     pub prefix: String,
 }
 
@@ -184,26 +168,13 @@ impl<'a> ListObjectsV2<'a> {
     /// # Errors
     ///
     /// Returns an error if the XML response could not be parsed.
-    pub fn parse_response(
-        s: impl AsRef<[u8]>,
-    ) -> Result<ListObjectsV2Response, quick_xml::DeError> {
-        Self::parse_response_from_reader(&mut s.as_ref())
-    }
-
-    /// Parse the XML response from S3 into a struct.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the XML response could not be parsed.
-    pub fn parse_response_from_reader(
-        s: impl Read,
-    ) -> Result<ListObjectsV2Response, quick_xml::DeError> {
-        let mut parsed: ListObjectsV2Response = quick_xml::de::from_reader(BufReader::new(s))?;
+    pub fn parse_response(s: &str) -> Result<ListObjectsV2Response, instant_xml::Error> {
+        let mut parsed: ListObjectsV2Response = instant_xml::from_str(s)?;
 
         // S3 returns an Owner with an empty DisplayName and ID when fetch-owner is disabled
         for content in &mut parsed.contents {
             if let Some(owner) = &content.owner {
-                if owner.id.is_empty() && owner.display_name.is_empty() {
+                if owner.id.is_empty() && owner.display_name.as_deref().is_none_or(str::is_empty) {
                     content.owner = None;
                 }
             }
@@ -303,8 +274,7 @@ mod tests {
 
     #[test]
     fn parse() {
-        let input = r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+        let input = r#"<?xml version="1.0" encoding="UTF-8"?>
         <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
             <Name>test</Name>
             <Prefix></Prefix>
@@ -384,8 +354,7 @@ mod tests {
 
     #[test]
     fn parse_no_contents() {
-        let input = r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+        let input = r#"<?xml version="1.0" encoding="UTF-8"?>
         <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
             <Name>test</Name>
             <Prefix></Prefix>

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -29,6 +29,9 @@ pub use self::multipart_upload::upload::UploadPart;
 pub use self::put_object::PutObject;
 use crate::{Map, Method};
 
+#[cfg(feature = "full")]
+pub(crate) const S3_XML_NS: &str = "http://s3.amazonaws.com/doc/2006-03-01/";
+
 mod create_bucket;
 mod delete_bucket;
 mod delete_object;

--- a/src/actions/multipart_upload/complete.rs
+++ b/src/actions/multipart_upload/complete.rs
@@ -1,8 +1,8 @@
 use std::iter;
 use std::time::Duration;
 
+use instant_xml::ToXml;
 use jiff::Timestamp;
-use serde::Serialize;
 use url::Url;
 
 use crate::actions::Method;
@@ -63,39 +63,33 @@ where
     ///
     /// Panics if an index is not representable as a `u16`.
     pub fn body(self) -> String {
-        #[derive(Serialize)]
-        #[serde(rename = "CompleteMultipartUpload")]
-        struct CompleteMultipartUploadSerde<'a> {
-            #[serde(rename = "Part")]
+        #[derive(ToXml)]
+        #[xml(rename = "CompleteMultipartUpload")]
+        struct CompleteMultipartUploadBody<'a> {
             parts: Vec<Part<'a>>,
         }
 
-        #[derive(Serialize)]
+        #[derive(ToXml)]
+        #[xml(rename = "Part")]
         struct Part<'a> {
-            #[serde(rename = "$value")]
-            nodes: Vec<Node<'a>>,
-        }
-
-        #[derive(Serialize)]
-        enum Node<'a> {
-            ETag(&'a str),
-            PartNumber(u16),
+            #[xml(rename = "ETag")]
+            etag: &'a str,
+            #[xml(rename = "PartNumber")]
+            part_number: u16,
         }
 
         let parts = self
             .etags
             .enumerate()
             .map(|(i, etag)| Part {
-                nodes: vec![
-                    Node::ETag(etag),
-                    Node::PartNumber(u16::try_from(i).expect("convert to u16") + 1),
-                ],
+                etag,
+                part_number: u16::try_from(i).expect("convert to u16") + 1,
             })
             .collect::<Vec<_>>();
 
-        let req = CompleteMultipartUploadSerde { parts };
+        let req = CompleteMultipartUploadBody { parts };
 
-        quick_xml::se::to_string(&req).unwrap()
+        instant_xml::to_string(&req).unwrap()
     }
 }
 

--- a/src/actions/multipart_upload/create.rs
+++ b/src/actions/multipart_upload/create.rs
@@ -1,13 +1,11 @@
-use std::io::{BufReader, Read};
 use std::iter;
 use std::time::Duration;
 
+use instant_xml::FromXml;
 use jiff::Timestamp;
-use serde::Deserialize;
 use url::Url;
 
-use crate::actions::Method;
-use crate::actions::S3Action;
+use crate::actions::{Method, S3_XML_NS, S3Action};
 use crate::signing::sign;
 use crate::sorting_iter::SortingIterator;
 use crate::{Bucket, Credentials, Map};
@@ -37,10 +35,10 @@ pub struct CreateMultipartUpload<'a> {
 #[derive(Debug, Clone)]
 pub struct CreateMultipartUploadResponse(InnerCreateMultipartUploadResponse);
 
-#[allow(clippy::module_name_repetitions)]
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, FromXml)]
+#[xml(rename = "InitiateMultipartUploadResult", ns(S3_XML_NS))]
 struct InnerCreateMultipartUploadResponse {
-    #[serde(rename = "UploadId")]
+    #[xml(rename = "UploadId")]
     upload_id: String,
 }
 
@@ -67,21 +65,8 @@ impl<'a> CreateMultipartUpload<'a> {
     /// # Errors
     ///
     /// Will return an error if the body is not valid XML
-    pub fn parse_response(
-        s: impl AsRef<[u8]>,
-    ) -> Result<CreateMultipartUploadResponse, quick_xml::DeError> {
-        Self::parse_response_from_reader(&mut s.as_ref())
-    }
-
-    /// Parse the XML response from S3
-    ///
-    /// # Errors
-    ///
-    /// Will return an error if the body is not valid XML
-    pub fn parse_response_from_reader(
-        s: impl Read,
-    ) -> Result<CreateMultipartUploadResponse, quick_xml::DeError> {
-        let parsed = quick_xml::de::from_reader(BufReader::new(s))?;
+    pub fn parse_response(s: &str) -> Result<CreateMultipartUploadResponse, instant_xml::Error> {
+        let parsed = instant_xml::from_str(s)?;
         Ok(CreateMultipartUploadResponse(parsed))
     }
 }

--- a/src/actions/multipart_upload/list_parts.rs
+++ b/src/actions/multipart_upload/list_parts.rs
@@ -1,13 +1,11 @@
-use std::io::BufRead;
 use std::iter;
 use std::time::Duration;
 
+use instant_xml::FromXml;
 use jiff::Timestamp;
-use serde::Deserialize;
 use url::Url;
 
-use crate::actions::Method;
-use crate::actions::S3Action;
+use crate::actions::{Method, S3_XML_NS, S3Action};
 use crate::signing::sign;
 use crate::sorting_iter::SortingIterator;
 use crate::{Bucket, Credentials, Map};
@@ -34,28 +32,28 @@ pub struct ListParts<'a> {
 }
 
 #[allow(clippy::module_name_repetitions)]
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, FromXml)]
+#[xml(rename = "ListPartsResult", ns(S3_XML_NS))]
 pub struct ListPartsResponse {
-    #[serde(rename = "Part")]
-    #[serde(default)]
     pub parts: Vec<PartsContent>,
-    #[serde(rename = "MaxParts")]
+    #[xml(rename = "MaxParts")]
     pub max_parts: u16,
-    #[serde(rename = "IsTruncated")]
+    #[xml(rename = "IsTruncated")]
     is_truncated: bool,
-    #[serde(rename = "NextPartNumberMarker")]
+    #[xml(rename = "NextPartNumberMarker")]
     pub next_part_number_marker: Option<u16>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, FromXml)]
+#[xml(rename = "Part", ns(S3_XML_NS))]
 pub struct PartsContent {
-    #[serde(rename = "PartNumber")]
+    #[xml(rename = "PartNumber")]
     pub number: u16,
-    #[serde(rename = "ETag")]
+    #[xml(rename = "ETag")]
     pub etag: String,
-    #[serde(rename = "LastModified")]
+    #[xml(rename = "LastModified")]
     pub last_modified: String,
-    #[serde(rename = "Size")]
+    #[xml(rename = "Size")]
     pub size: u64,
 }
 
@@ -92,19 +90,8 @@ impl<'a> ListParts<'a> {
     /// # Errors
     ///
     /// Will return an error if the XML cannot be deserialized
-    pub fn parse_response(s: impl AsRef<[u8]>) -> Result<ListPartsResponse, quick_xml::DeError> {
-        Self::parse_response_from_reader(&mut s.as_ref())
-    }
-
-    /// Parse the XML response from S3 into a struct
-    ///
-    /// # Errors
-    ///
-    /// Will return an error if the XML cannot be deserialized
-    pub fn parse_response_from_reader(
-        s: impl BufRead,
-    ) -> Result<ListPartsResponse, quick_xml::DeError> {
-        let mut parts: ListPartsResponse = quick_xml::de::from_reader(s)?;
+    pub fn parse_response(s: &str) -> Result<ListPartsResponse, instant_xml::Error> {
+        let mut parts: ListPartsResponse = instant_xml::from_str(s)?;
         if !parts.is_truncated {
             parts.next_part_number_marker = None;
         }
@@ -217,8 +204,7 @@ mod tests {
 
     #[test]
     fn parse() {
-        let input = r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+        let input = r#"<?xml version="1.0" encoding="UTF-8"?>
         <ListPartsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
           <Bucket>example-bucket</Bucket>
           <Key>example-object</Key>
@@ -272,8 +258,7 @@ mod tests {
 
     #[test]
     fn parse_no_parts() {
-        let input = r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+        let input = r#"<?xml version="1.0" encoding="UTF-8"?>
         <ListPartsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
           <Bucket>example-bucket</Bucket>
           <Key>example-object</Key>


### PR DESCRIPTION
`quick-xml` relies on serde, which does not map well with xml. This switches to `instant-xml`, which uses it's own system for serialization and deserialization. It doesn't support streaming decoding, but I hope people don't mind too much.

I'll test this more in the following days.